### PR TITLE
Choose plotlyjs() backend within plotting code && update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ end
 using easyplotting; retry(easyplotting.easymain::Function, delays=ExponentialBackOff(n=5, first_delay=5, max_delay=10))() ## Retry function in case of an IOError when launching Blink
 ```
 
-Press enter. If this is your first time using this package, it could take up to 20 min for the full installation process.
+Press enter. If this is your first time using this package, it could 15-20 min for the full installation process.
+
+Also, kindly note that it may take a while for the plot to load after clicking the 'Plot' button, sometimes up to 2 min.
 
 If you have already installed this easyplotting.jl package, you may prefer to launch the GUI by copying and pasting this instead at the Julia prompt:
 
@@ -79,6 +81,7 @@ sudo ln -s ~/julia-1.1.1/bin/julia /usr/local/bin/julia
 
 Replace 'julia-1.1.1' with the respective folder name. Then run Julia by simply typing `julia` in the terminal. [Click here](https://julialang.org/downloads/platform.html) for more information.
 
+Also, if you are using wayland as your display server protocol, after the easyplotting installation process, you would also need to type this on your bash shell to switch the qt5 plotting platform to wayland: `QT_QPA_PLATFORM=wayland`.
 ***
 
 ## Credits:

--- a/src/easybarchart.jl
+++ b/src/easybarchart.jl
@@ -72,6 +72,7 @@ function easybarchart()
             end
 
             ## Plot barchart
+            StatsPlots.plotlyjs() ## Using PLotlyJS backend
             if easybarchart_inputsFn["easybarchart_size1"][]::String == "" ## If no user-input for plot size
                 if easybarchart_inputsFn["easybarchart_scale"][] == "None" ## For no logarithmic scaling
                     StatsPlots.bar(collect(df[:,2]), xlabel = string(names(df)[2]), xticks = (1:length(df[:,1]), df[:,1]), color=Symbol(easybarchart_inputsFn["easybarchart_colours"][]), legend=false)

--- a/src/easyboxandwhisker.jl
+++ b/src/easyboxandwhisker.jl
@@ -72,6 +72,7 @@ function easyboxandwhisker()
             end
 
             ## Plot boxandwhisker
+            StatsPlots.plotlyjs() ## Using PLotlyJS backend
             if easyboxandwhisker_inputsFn["easyboxandwhisker_size1"][]::String == "" ## If no user-input for plot size
                 if easyboxandwhisker_inputsFn["easyboxandwhisker_scale"][] == "None" ## For no logarithmic scaling
                     StatsPlots.boxplot(convert(Matrix, df[:,2:end]), xticks = (1:size(df[:,2:end],2), [string(names(df)[i]) for i in 2:size(df,2)]), color=Symbol(easyboxandwhisker_inputsFn["easyboxandwhisker_colours"][]), legend=false)

--- a/src/easyhistogram.jl
+++ b/src/easyhistogram.jl
@@ -74,6 +74,7 @@ aframe
             end
 
             ## Plot histogram
+            StatsPlots.plotlyjs() ## Using PLotlyJS backend
             if easyhistogram_inputsFn["easyhistogram_size1"][]::String == "" ## If no user-input for plot size
                 if easyhistogram_inputsFn["easyhistogram_scale"][] == "None" ## For no logarithmic scaling
                     StatsPlots.histogram(collect(df[:,2]), xlabel = string(names(df)[2]), color=Symbol(easyhistogram_inputsFn["easyhistogram_colours"][]), legend=false)

--- a/src/easylinegraph.jl
+++ b/src/easylinegraph.jl
@@ -72,6 +72,7 @@ function easylinegraph()
             end
 
             ## Plot linegraph
+            StatsPlots.plotlyjs() ## Using PLotlyJS backend
             if easylinegraph_inputsFn["easylinegraph_size1"][]::String == "" ## If no user-input for plot size
                 if easylinegraph_inputsFn["easylinegraph_scale"][] == "None" ## For no logarithmic scaling
                     StatsPlots.plot(convert(Matrix, df[:,2:end]), marker = true, markersize = 4, label = [string(names(df)[i]) for i in 2:size(df,2)], color=Symbol(easylinegraph_inputsFn["easylinegraph_colours"][]), legend=true)

--- a/src/easypiechart.jl
+++ b/src/easypiechart.jl
@@ -68,6 +68,7 @@ aframe
             end
 
             ## Plot piechart
+            StatsPlots.plotlyjs() ## Using PLotlyJS backend
             if easypiechart_inputsFn["easypiechart_size1"][]::String == "" ## If no user-input for plot size
                 if easypiechart_inputsFn["easypiechart_scale"][] == "None" ## For no logarithmic scaling
                     StatsPlots.pie(collect(df[:,1]), collect(df[:,2]), xlabel = string(names(df)[2]))

--- a/src/easyplotting.jl
+++ b/src/easyplotting.jl
@@ -1,7 +1,6 @@
 module easyplotting ## Define easyplotting module
 
 using Blink, Interact, XLSX, CSV, DelimitedFiles, DataFrames, StatsPlots, PlotlyJS, Seaborn, Conda, FileIO, ImageView ## Importing required libraries for all downstream functions
-StatsPlots.plotlyjs() ## Using PLotlyJS backend for all plots by StatsPlots package
 
 ## Include all source scripts
 include("easymain.jl")

--- a/src/easyscatterplot2d.jl
+++ b/src/easyscatterplot2d.jl
@@ -72,6 +72,7 @@ function easyscatterplot2d()
             end
 
             ## Plot scatterplot2d
+            StatsPlots.plotlyjs() ## Using PLotlyJS backend
             if easyscatterplot2d_inputsFn["easyscatterplot2d_size1"][]::String == "" ## If no user-input for plot size
                 if easyscatterplot2d_inputsFn["easyscatterplot2d_scale"][] == "None" ## For no logarithmic scaling
                     StatsPlots.scatter(collect(df[:,2]), collect(df[:,3]), xlabel = string(names(df)[2]), ylabel = string(names(df)[3]), color=Symbol(easyscatterplot2d_inputsFn["easyscatterplot2d_colours"][]), legend=false)

--- a/src/easyscatterplot3d.jl
+++ b/src/easyscatterplot3d.jl
@@ -72,6 +72,7 @@ function easyscatterplot3d()
             end
 
             ## Plot scatterplot3d
+            StatsPlots.plotlyjs() ## Using PLotlyJS backend
             if easyscatterplot3d_inputsFn["easyscatterplot3d_size1"][]::String == "" ## If no user-input for plot size
                 if easyscatterplot3d_inputsFn["easyscatterplot3d_scale"][] == "None" ## For no logarithmic scaling
                     StatsPlots.scatter3d(collect(df[:,2]), collect(df[:,3]), collect(df[:,4]), xlabel = string(names(df)[2]), ylabel = string(names(df)[3]), zlabel = string(names(df)[4]),


### PR DESCRIPTION
Remove plotlyjs() backend from main easyplotting.jl code and instead including it within plotting code. Also, update README for Linux users to manually switch qt5 backend to wayland on bash shell.